### PR TITLE
fix: invalid path on Windows

### DIFF
--- a/rules/progress.js
+++ b/rules/progress.js
@@ -1,5 +1,6 @@
 const ora = require('ora');
 const chalk = require('chalk');
+const path = require('path');
 
 const spinner = ora({
   spinner: 'line',
@@ -22,7 +23,8 @@ const create = (context) => {
   }
 
   const filename = context.getFilename();
-  const relativeFilePath = filename.replace(rootPath, '');
+
+  const relativeFilePath = path.relative(rootPath, filename);
 
   spinner.text = `Processing: ${chalk.green(relativeFilePath)} \n`;
   spinner.render();


### PR DESCRIPTION
The output displayed full path instead of relative path due to Directory Separator (`/` vs `\`).

Before:
```sh
- Processing: C:\Users\Nelson Martell\Documents\GitHub\forks\eslint-plugin-file-progress\rules\progress.js
```

After: 
```sh
- Processing: rules\progress.js
```

Tested on Windows and Linux OSs.