### PR TITLE
Allows custom lint done message

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -8,6 +8,11 @@ plugins:
 
 rules:
   file-progress/activate: 1
+settings:
+  progress:
+    hide-progress: false
+    success-message: "Lint done..."
+    fail-message: "Lint done with errors."
 
 env:
   node: true

--- a/README.md
+++ b/README.md
@@ -26,6 +26,11 @@ plugins:
 
 rules:
   file-progress/activate: 1
+settings:
+  progress:
+    hide-progress: false
+    success-message: "Lint done..."
+    fail-message: "Lint done with errors."
 ```
 
 ### Demo

--- a/rules/progress.js
+++ b/rules/progress.js
@@ -7,10 +7,21 @@ const spinner = ora({
 });
 
 let bindExit = false;
+let initialReportDone = false;
 
-const exitCallback = (exitCode) => {
+const exitCallback = (exitCode, settings) => {
   if (exitCode === 0) {
-    spinner.succeed('Lint done...');
+    spinner.succeed(
+      settings && typeof settings['success-message'] === 'string'
+        ? settings['success-message']
+        : 'Lint done...',
+    );
+  } else {
+    spinner.fail(
+      settings && typeof settings['fail-message'] === 'string'
+        ? settings['fail-message']
+        : 'Lint done with errors.',
+    );
   }
 };
 
@@ -18,15 +29,23 @@ const rootPath = process.cwd();
 
 const create = (context) => {
   if (!bindExit) {
-    process.on('exit', exitCallback);
+    process.on('exit', (code) => {
+      exitCallback(code, context.settings);
+    });
     bindExit = true;
   }
 
-  const filename = context.getFilename();
-  const relativeFilePath = path.relative(rootPath, filename);
+  if (!context.settings['hide-progress']) {
+    const filename = context.getFilename();
+    const relativeFilePath = path.relative(rootPath, filename);
 
-  spinner.text = `Processing: ${chalk.green(relativeFilePath)} \n`;
-  spinner.render();
+    spinner.text = `Processing: ${chalk.green(relativeFilePath)} \n`;
+    spinner.render();
+  } else if (!initialReportDone) {
+    spinner.text = 'Linting \n';
+    spinner.render();
+    initialReportDone = true;
+  }
 
   return {};
 };

--- a/test.js
+++ b/test.js
@@ -8,6 +8,13 @@ const ruleName = 'file-progress/activate';
 ruleTester.run(ruleName, progress, {
   valid: [
     'var foo = \'bar\'',
+    {
+      code: 'var foo = \'bar\'',
+      settings: {
+        'hide-progress': true,
+        'success-message': 'API lint done...',
+      },
+    },
   ],
   invalid: [],
 });


### PR DESCRIPTION
Hi there, this is my first time doing something to an eslint plugin, unfortunately I couldn't test this nor able to install `node_modules`

I get error from `yarn install`:
```
error eslint@8.18.0: The engine "node" is incompatible with this module. Expected version "^12.22.0 || ^14.17.0 || >=16.0.0". Got "14.15.3"
error Found incompatible module.
```

and `npm install`:

```
npm ERR! Maximum call stack size exceeded
```

Unfortionately I cannot either switch my node env now. Can you please check and let me know if I'm missing anything, the suggested idea of what I wanted to achieve is in the `README.md`

The reason behind this PR is because I have multiple projects and I run their lint in sequence, it would be nice to know what the lint is done for.

Also I want to add an additional rules:
- `hide-progress` to hide file progress, just stick to the end message for pipelines purposes.
- if `exitCode` is other than `0` then maybe write `Done with errors`.

If you approve the other 2 features, please let me know and I'll adjust the code accordingly.