### PR TITLE
chore: use namespaced names for config presets

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@ const plugin = {
 
 const configs = {
   recommended: {
-    name: 'recommended',
+    name: 'eslint-plugin-file-progress/recommended',
     plugins: {
       progress: plugin
     },
@@ -22,7 +22,7 @@ const configs = {
     }
   },
   noCI: {
-    name: 'no-ci',
+    name: 'eslint-plugin-file-progress/no-ci',
     plugins: {
       progress: plugin
     },

--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@ const plugin = {
 
 const configs = {
   recommended: {
-    name: 'eslint-plugin-file-progress/recommended',
+    name: 'progress/recommended',
     plugins: {
       progress: plugin
     },
@@ -22,7 +22,7 @@ const configs = {
     }
   },
   noCI: {
-    name: 'eslint-plugin-file-progress/no-ci',
+    name: 'progress/no-ci',
     plugins: {
       progress: plugin
     },


### PR DESCRIPTION
Adds proper name to the config presets.

The names are shown during inspection and for debugging purposes, so it is useful to have a more verbose name for the preview.

| Before | After |
| --- | --- |
| ![grafik](https://github.com/user-attachments/assets/1d55bc5f-1554-4140-aeb0-4e9d7924af61) | ![grafik](https://github.com/user-attachments/assets/8fb6e185-18c4-44a5-bf8c-13fbae196344) |

````ts
pnpm eslint --inspect-config --flag unstable_ts_config
````