### PR TITLE
types: add missing noCI config preset key

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -6,7 +6,8 @@ declare const plugin: {
     version: string;
   };
   configs: {
-    recommended: Linter.Config
+    recommended: Linter.Config;
+    noCI: Linter.Config;
   };
   rules: {
     activate: Rule.RuleModule;


### PR DESCRIPTION
Adds the `noCI` key to the config presets.

https://github.com/sibiraj-s/eslint-plugin-file-progress/blob/eab0b52dce4d0cf821acdfb88be8c8549f2bc1e4/index.js#L24

Although I would recommend renaming the key to `recommended-noCI` or similar to make it more obvious, that it is the recommended preset with additional settings.
