### PR TITLE
fix: exit spinner respect hide setting

### DIFF
--- a/rules/progress.js
+++ b/rules/progress.js
@@ -17,7 +17,7 @@ const defaultSettings = {
 };
 
 const exitCallback = (exitCode, settings) => {
-  if (exitCode === 0) {
+  if (exitCode === 0 && settings.hide !== true) {
     spinner.success({ text: settings.successMessage });
   }
 };


### PR DESCRIPTION
It still have spinner when I use hide setting and run in the VSCode with ESLint extension.

When I setting the hide value as true when using in VSCode like this:

```
import progress from 'eslint-plugin-file-progress'

export default [
  {
    ...progress.configs.recommended,
    settings: {
      progress: {
        hide: Boolean(process.env.VSCODE_PID)
      }
    }
  }
]
```

Then ESLint console in the VSCode just like this, that still have spinner:

![截圖 2025-03-04 13 35 03](https://github.com/user-attachments/assets/2712fcd3-7383-405d-ad6f-1d16e4014682)

The reason of this, because the exitCallback not respect hide setting.
